### PR TITLE
Finish URL Loading when observing requests to make sure all URL requests  are finished before the test method returns.

### DIFF
--- a/EssentialFeed/EssentialFeedTests/Feed Api/URLSessionHTTPClientTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Api/URLSessionHTTPClientTests.swift
@@ -209,7 +209,6 @@ class URLSessionHTTPClientTests: XCTestCase {
         }
         
         override class func canInit(with request: URLRequest) -> Bool {
-            requestObserver?(request)
             return true
         }
         
@@ -218,6 +217,11 @@ class URLSessionHTTPClientTests: XCTestCase {
         }
         
         override func startLoading() {
+            if let requestObserver = Self.requestObserver {
+                client?.urlProtocolDidFinishLoading(self)
+                return requestObserver(request)
+            }
+            
             if let data = Self.stub?.data {
                 client?.urlProtocol(self, didLoad: data)
             }


### PR DESCRIPTION
This way, we prevent data race with threads living longer than test method that initiated them