### PR TITLE
ci: Remove parallelization flag from CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,6 +32,5 @@ jobs:
         xcodebuild clean build test \
         -project EssentialFeed/EssentialFeed.xcodeproj \
         -scheme "CI_iOS" \
-        -parallel-testing-enabled NO \
         -destination 'platform=iOS Simulator,name=iPhone 16' \
         CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO


### PR DESCRIPTION
CI was previously failing due to two separate issues:

- **SQLite I/O disk error**
- **Ambiguous `NSEntityDescription` errors**

These issues came from two different levels of parallelization:

- **Intra-target parallelization**: test methods within the same target running in parallel.
- **Inter-target parallelization**: test targets running in parallel (introduced with test plans).

#### ✅ Fixes

- The **SQLite I/O error** was fixed by **disabling intra-target parallelization** for the `EssentialFeedCacheIntegrationTests` target, since it mutates shared state (file system).
- The **NSEntityDescription ambiguity** was fixed by **making the Core Data model a `static let`**, ensuring it’s loaded only once in memory (instead of once per test target).

#### ❌ Removing the flag

The `-parallel-testing-enabled NO` flag globally disables **all forms of parallelization**, including inter-target, which increases CI times. Since both issues have now been resolved at their root, the flag is no longer necessary.